### PR TITLE
Add clean command

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ Integrate the `concat` function into your Zsh environment by selecting one of th
    # -> summary.txt
    ```
 
+6. **Remove old output files**
+
+   ```zsh
+   concat clean
+   ```
+
 ## Usage
 
 ### Basic Syntax
@@ -173,6 +179,8 @@ Integrate the `concat` function into your Zsh environment by selecting one of th
 ```zsh
 concat [OPTIONS] [FILE...]
 ```
+
+Run `concat clean` to delete existing `_concat-*` files without performing a new concatenation.
 
 ### Positional Arguments
 
@@ -258,6 +266,12 @@ concat [OPTIONS] [FILE...]
    ```zsh
    concat /
    # -> _concat-output.txt
+   ```
+
+8. **Clean up old outputs**
+
+   ```zsh
+   concat clean
    ```
 
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Integrate the `concat` function into your Zsh environment by selecting one of th
 6. **Remove old output files**
 
    ```zsh
-   concat clean -r logs/
+   concat clean logs/
    ```
 
    Pass the same filtering options as regular runs to target specific files.
@@ -182,7 +182,7 @@ Integrate the `concat` function into your Zsh environment by selecting one of th
 concat [OPTIONS] [FILE...]
 ```
 
-Run `concat clean [OPTIONS] [DIR...]` to delete existing `_concat-*` files. You can use the same include/exclude and recursive flags as in normal runs.
+Run `concat clean [OPTIONS] [DIR...]` to delete existing `_concat-*` files. This command searches recursively by default; use `-n` to disable recursion. Other include/exclude flags work the same as for normal runs.
 
 ### Positional Arguments
 
@@ -273,7 +273,7 @@ Run `concat clean [OPTIONS] [DIR...]` to delete existing `_concat-*` files. You 
 8. **Clean up old outputs**
 
    ```zsh
-   concat clean -r subdir/ -e '*backup*'
+   concat clean -n subdir/ -e '*backup*'
    ```
 
 

--- a/README.md
+++ b/README.md
@@ -169,8 +169,10 @@ Integrate the `concat` function into your Zsh environment by selecting one of th
 6. **Remove old output files**
 
    ```zsh
-   concat clean
+   concat clean -r logs/
    ```
+
+   Pass the same filtering options as regular runs to target specific files.
 
 ## Usage
 
@@ -180,7 +182,7 @@ Integrate the `concat` function into your Zsh environment by selecting one of th
 concat [OPTIONS] [FILE...]
 ```
 
-Run `concat clean` to delete existing `_concat-*` files without performing a new concatenation.
+Run `concat clean [OPTIONS] [DIR...]` to delete existing `_concat-*` files. You can use the same include/exclude and recursive flags as in normal runs.
 
 ### Positional Arguments
 
@@ -271,7 +273,7 @@ Run `concat clean` to delete existing `_concat-*` files without performing a new
 8. **Clean up old outputs**
 
    ```zsh
-   concat clean
+   concat clean -r subdir/ -e '*backup*'
    ```
 
 

--- a/concat.zsh
+++ b/concat.zsh
@@ -107,7 +107,7 @@ EOF
 
     if [[ "$1" == "clean" ]]; then
         shift
-        local recursive=false includeHidden=false verbose=false
+        local recursive=true includeHidden=false verbose=false
         local -a includeGlobs excludeGlobs exts ignoreExts paths
 
         while (( $# )); do
@@ -117,10 +117,10 @@ EOF
 Usage: concat clean [OPTIONS] [DIR...]
 
 Remove files named '_concat-*' from specified directories (default: current directory).
+Searches directories recursively by default.
 
 Options:
-  -r, --recursive            Search directories recursively.
-  -n, --no-recursive         Do not search recursively (default).
+  -n, --no-recursive         Do not search directories recursively.
   -I, --include <glob>       Only delete files whose path matches this glob.
   -e|-E|--exclude <glob>     Exclude files matching this glob.
   -x, --ext <ext>            Only delete files with this extension.
@@ -130,9 +130,6 @@ Options:
   -h, --help                 Show this help message.
 EOF
                     return 0
-                ;;
-                -r|--recursive)
-                    recursive=true; shift; continue
                 ;;
                 -n|--no-recursive)
                     recursive=false; shift; continue

--- a/concat.zsh
+++ b/concat.zsh
@@ -40,6 +40,7 @@ concat() {
         if [[ "$arg" == "-h" || "$arg" == "--help" ]]; then
             cat <<EOF
 Usage: concat [OPTIONS] [FILE...]
+       concat clean
 
 Concatenates files matching specified criteria into a single output file.
 
@@ -97,10 +98,34 @@ Options:
 
   -h, --help
       Show this help message and exit.
+  clean
+      Remove previously generated _concat-* files from the current directory.
 EOF
             return 0
         fi
     done
+
+    if [[ "$1" == "clean" ]]; then
+        shift
+        local verbose=false
+        if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+            cat <<EOF
+Usage: concat clean [-v]
+
+Deletes files named '_concat-*' in the current directory.
+EOF
+            return 0
+        fi
+        if [[ "$1" == "-v" || "$1" == "--verbose" ]]; then
+            verbose=true
+        elif [[ -n "$1" ]]; then
+            echo "Error: Unknown option '$1' for clean command." >&2
+            return 1
+        fi
+        [[ "$verbose" == true ]] && echo "Deleting existing _concat-* files"
+        find . -maxdepth 1 -type f -name "_concat-*" -exec rm -f {} +
+        return 0
+    fi
 
     # -------------------------------------------------------------------------
     # Save Original Arguments


### PR DESCRIPTION
## Summary
- add `clean` command to delete old `_concat-*` outputs
- document the `clean` command in README

## Testing
- `cargo test --quiet`
- `shellcheck concat.zsh` *(fails: SC2296 etc. but ran)*

------
https://chatgpt.com/codex/tasks/task_e_6840a8b33ed4832094687929db662718